### PR TITLE
Rotation Issues Question

### DIFF
--- a/Rotation Issue/AppDelegate.swift
+++ b/Rotation Issue/AppDelegate.swift
@@ -50,6 +50,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     func splitViewController(_ splitViewController: UISplitViewController, collapseSecondary secondaryViewController:UIViewController, onto primaryViewController:UIViewController) -> Bool {        
         return false
     }
+  
+    func splitViewController(_ svc: UISplitViewController, willChangeTo displayMode: UISplitViewControllerDisplayMode) {
+
+        // This is not ideal because it kind of just assumes the hierarchy, but this is the rough idea. The Split view knows when it changes and notifies it's descendants.
+        svc.childViewControllers.forEach { vc in
+            if let detail = vc.childViewControllers.first as? DetailViewController {
+                detail.collectionViewLayout.invalidateLayout()
+            }
+        }
+    }
 
 }
 

--- a/Rotation Issue/DetailViewController.swift
+++ b/Rotation Issue/DetailViewController.swift
@@ -14,6 +14,10 @@ class DetailViewController: UICollectionViewController {
     fileprivate let numCells = 10
     fileprivate let sectionInsets = UIEdgeInsets(top: 50.0, left: 20.0, bottom: 50.0, right: 20.0)
     
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        self.collectionViewLayout.invalidateLayout()
+    }
+    
 }
 
 extension DetailViewController : UICollectionViewDelegateFlowLayout {


### PR DESCRIPTION
A quick look at this, it appears that if you use `viewWillTransitionToSize` as the point to ask for invalidation, it works as expected.

https://developer.apple.com/reference/uikit/uicontentcontainer/1621466-viewwilltransitiontosize

There is another issue on the split view controller too when collapsing it. The Traits don't change in that context so `traitCollectionDidChange` is not the right override. It might have to be done from the split view's point of view. That's just off the top of my head. I can look it up later if you don't have ideas.